### PR TITLE
fix: register library item delete route

### DIFF
--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -359,6 +359,31 @@ func TestEngineLibraryFileRouteGetNotFound(t *testing.T) {
 	require.NotEmpty(t, payload.Message)
 }
 
+func TestEngineLibraryItemRouteDelete(t *testing.T) {
+	saveDir := t.TempDir()
+	itemDir := filepath.Join(saveDir, "demo")
+	require.NoError(t, os.MkdirAll(itemDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(itemDir, "movie.nfo"), []byte("<movie></movie>"), 0o644))
+
+	api := &API{saveDir: saveDir}
+	engine, err := api.Engine(":0")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/library/item?path=demo", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var payload struct {
+		Code int `json:"code"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	require.Equal(t, 0, payload.Code)
+	_, statErr := os.Stat(itemDir)
+	require.True(t, os.IsNotExist(statErr))
+}
+
 func TestHandlePluginEditorCompile(t *testing.T) {
 	editorSvc, err := plugineditor.NewService(client.MustNewClient())
 	require.NoError(t, err)

--- a/internal/web/library_routes.go
+++ b/internal/web/library_routes.go
@@ -6,6 +6,7 @@ func (a *API) registerEngineLibraryRoutes(group *gin.RouterGroup) {
 	group.GET("/api/library", gin.WrapF(a.handleListLibrary))
 	group.GET("/api/library/item", gin.WrapF(a.handleLibraryItem))
 	group.PATCH("/api/library/item", gin.WrapF(a.handleLibraryItem))
+	group.DELETE("/api/library/item", gin.WrapF(a.handleLibraryItem))
 	group.GET("/api/library/file", gin.WrapF(a.handleLibraryFile))
 	group.DELETE("/api/library/file", gin.WrapF(a.handleLibraryFile))
 	group.POST("/api/library/asset", gin.WrapF(a.handleLibraryAsset))


### PR DESCRIPTION
## Summary
- register DELETE /api/library/item so deleting savedir conflicts reaches the backend handler
- add an API test covering successful deletion of a saved library item directory

## Verification
- go test ./internal/web ./internal/medialib
- make lint-go
- cd web && npm run build